### PR TITLE
bench: Fix passing non-standard port to telnet control

### DIFF
--- a/bench/control.py
+++ b/bench/control.py
@@ -171,7 +171,7 @@ class TelnetControl(Control):
 
         self.address = address
         self.port = port
-        self.telnet_client = telnetlib.Telnet(address)
+        self.telnet_client = telnetlib.Telnet(address, port)
         self.prompt = self.prompt.replace('"', '')
 
 


### PR DESCRIPTION
Non-standard ports would not be passed to the TelnetControl class,
leading to telnetlib using the standard telnet port.

Fixes: c6fd6d80d91c ("bench: Support non standard protocol ports")