### PR TITLE
Vlan

### DIFF
--- a/dsatest/bench/interface.py
+++ b/dsatest/bench/interface.py
@@ -10,6 +10,7 @@ class Interface(object):
         self.machine = machine
         self.switch = switch
         self.port_id = port_id
+        self.vlan_interfaces = {}
 
 
     def __repr__(self):
@@ -39,3 +40,19 @@ class Interface(object):
 
     def arp_get(self, address):
         return self.machine.arp_get(address, self.name)
+
+    def add_vlan(self, vid):
+        ret = self.machine.add_vid(self.name, vid)
+        """ Treat existing interfaces as okay """
+        if ret != 0:
+            return ret
+        vlan = Interface("{}.{}".format(self.name, vid),
+                         self.machine, self.switch, self.port_id)
+        self.vlan_interfaces[vid] = vlan
+
+    def del_vlan(self, vid):
+        ret = self.machine.del_vid(self.name, vid)
+        if ret != 0:
+            return ret
+        del self.vlan_interfaces[vid]
+

--- a/dsatest/bench/machine.py
+++ b/dsatest/bench/machine.py
@@ -80,3 +80,13 @@ class Machine:
                 return mac
 
         return None
+
+    def add_vid(self, interface, vid):
+        command = "ip link add {0}.{1} link {0} type vlan id {1}".format(interface, vid)
+        ret, _, _ = self.control.execute(command)
+        return ret
+
+    def del_vid(self, interface, vid):
+        command = "ip link del {0}.{1}".format(interface, vid)
+        ret, _, _, = self.control.execute(command)
+        return ret

--- a/dsatest/tests/helpers.py
+++ b/dsatest/tests/helpers.py
@@ -53,3 +53,19 @@ def up_and_wait(up_interfaces, monitored=None, expand=True):
         timeout = timeout - 1
 
     raise RuntimeError("some interfaces did not up within alloted period")
+
+def get_address(offset, side, prefix_length=None):
+    if side == "host":
+        side = "1"
+    elif side == "target":
+        side = "2"
+    else:
+        raise ValueError("unexpected side")
+
+    address = "192.168.{}.{}".format(str(10 + offset), side)
+    if prefix_length:
+        address = "{}/{}".format(address, prefix_length)
+
+    return address
+
+

--- a/dsatest/tests/port/ping.py
+++ b/dsatest/tests/port/ping.py
@@ -2,25 +2,10 @@
 import unittest
 
 from dsatest.bench import bench
-from dsatest.tests.helpers import up_and_wait
+from dsatest.tests.helpers import up_and_wait, get_address
 
 @unittest.skipIf(not bench.links, "Empty link list")
 class TestPing(unittest.TestCase):
-
-    def get_address(self, offset, side, prefix_length=None):
-        if side == "host":
-            side = "1"
-        elif side == "target":
-            side = "2"
-        else:
-            raise ValueError("unexpected side")
-
-        address = "192.168.{}.{}".format(str(10 + offset), side)
-        if prefix_length:
-            address = "{}/{}".format(address, prefix_length)
-
-        return address
-
 
     def setUp(self):
         links = bench.links
@@ -28,22 +13,22 @@ class TestPing(unittest.TestCase):
         for i, link in enumerate(links):
             up_and_wait(link)
             link.host_if.flush_addresses()
-            link.host_if.add_address(self.get_address(i, "host", 24))
+            link.host_if.add_address(get_address(i, "host", 24))
             link.target_if.flush_addresses()
-            link.target_if.add_address(self.get_address(i, "target", 24))
+            link.target_if.add_address(get_address(i, "target", 24))
 
 
     def tearDown(self):
         links = bench.links
 
         for i, link in enumerate(links):
-            link.host_if.del_address(self.get_address(i, "host", 24))
+            link.host_if.del_address(get_address(i, "host", 24))
             link.host_if.down()
-            link.target_if.del_address(self.get_address(i, "target", 24))
+            link.target_if.del_address(get_address(i, "target", 24))
             link.target_if.down()
 
 
     def test_port_ping_all(self):
         for i, link in enumerate(bench.links):
-            addr = self.get_address(i, "target")
+            addr = get_address(i, "target")
             link.host_if.ping(addr, count=1, deadline=10)

--- a/dsatest/tests/port/vlan.py
+++ b/dsatest/tests/port/vlan.py
@@ -1,0 +1,50 @@
+
+import unittest
+
+from dsatest.bench import bench
+from dsatest.tests.helpers import up_and_wait, get_address
+
+@unittest.skipIf(not bench.links, "Empty link list")
+class TestPingVlan(unittest.TestCase):
+
+    VID_START = 0
+    VID_END = 10
+
+    def setUp(self):
+        links = bench.links
+
+        for i, link in enumerate(links):
+            up_and_wait(link)
+            link.host_if.flush_addresses()
+            link.target_if.flush_addresses()
+            for vid in range(TestPingVlan.VID_START, TestPingVlan.VID_END):
+                link.host_if.add_vlan(vid)
+                link.target_if.add_vlan(vid)
+
+
+    def tearDown(self):
+        links = bench.links
+
+        for i, link in enumerate(links):
+            for vid in range(TestPingVlan.VID_START, TestPingVlan.VID_END):
+                link.target_if.del_vlan(vid)
+                link.host_if.del_vlan(vid)
+            link.host_if.down()
+            link.target_if.down()
+
+
+    def test_port_ping_vlan_all(self):
+        for i, link in enumerate(bench.links):
+            for vid in range(TestPingVlan.VID_START, TestPingVlan.VID_END):
+                host_vlan = link.host_if.vlan_interfaces[vid]
+                target_vlan = link.target_if.vlan_interfaces[vid]
+                host_vlan.add_address(get_address(vid, "host", 24))
+                host_vlan.up()
+                target_vlan.add_address(get_address(vid, "target", 24))
+                target_vlan.up()
+                addr = get_address(vid, "target")
+                host_vlan.ping(addr, count=1, deadline=10)
+                host_vlan.flush_addresses()
+                target_vlan.flush_addresses()
+                host_vlan.down()
+                target_vlan.down()


### PR DESCRIPTION
I am seeing the following error that I don't quite understand, must be something wrong with my handling of the list indexes...:

`
DEBUG: TelnetControl: Executing: ip link del gphy.2
DEBUG: TelnetControl: Command returned 0
DEBUG: LocalControl: Executing: ip link del eth1.2
DEBUG: LocalControl: Command returned 0
DEBUG: TelnetControl: Executing: ip link del gphy.3
DEBUG: TelnetControl: Command returned 0
EE
======================================================================
ERROR: test_port_ping_vlan_all (tests.port.vlan.TestPingVlan)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/fainelli/dev/github/dsatest/dsatest/tests/port/vlan.py", line 39, in test_port_ping_vlan_all
    host_vlan = link.host_if.vlan_interfaces[vid]
IndexError: list index out of range

======================================================================
ERROR: test_port_ping_vlan_all (tests.port.vlan.TestPingVlan)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/fainelli/dev/github/dsatest/dsatest/tests/port/vlan.py", line 30, in tearDown
    link.target_if.del_vlan(vid)
  File "/home/fainelli/dev/github/dsatest/dsatest/bench/interface.py", line 57, in del_vlan
    self.vlan_interfaces.pop(vid)
IndexError: pop index out of range

----------------------------------------------------------------------
Ran 1 test in 4.639s

FAILED (errors=2)
zsh: exit 2     sudo ./dsatest.sh -B ~/.dsatest/7278.cfg -t port_ping_vlan_all -vvv

`