### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM alpine
+MAINTAINER Vivien Didelot <vivien.didelot@savoirfairelinux.com>
+
+RUN apk update \
+ && apk upgrade \
+ && apk add --no-cache \
+    build-base \
+    iproute2 \
+    libffi \
+    libffi-dev \
+    openssh \
+    openssl \
+    openssl-dev \
+    python3 \
+    python3-dev \
+ && pip3 install --no-cache-dir --upgrade \
+    configparser \
+    paramiko \
+    pip \
+    setuptools \
+ && apk del \
+    build-base \
+    libffi-dev \
+    openssl-dev \
+    python3-dev \
+ && apk info
+
+WORKDIR /opt/dsatest
+COPY . .
+RUN python3 setup.py install
+WORKDIR /
+RUN rm -rf /opt/dsatest
+
+ENTRYPOINT ["dsatest", "-f", "/etc/bench.cfg"]

--- a/README.adoc
+++ b/README.adoc
@@ -27,8 +27,8 @@ Ensure that the framework is functional by listing the tests and running the san
 
 [source,sh]
 ----
-./dsatest -l -B bench.cfg.example
-./dsatest --dry-run -t sanity -B bench.cfg.example
+./dsatest -l -f bench.cfg.example
+./dsatest --dry-run -t sanity -f bench.cfg.example
 ----
 
 === Configuring

--- a/docs/conf-example.adoc
+++ b/docs/conf-example.adoc
@@ -17,7 +17,7 @@ A simple 4-port Ethernet switch looks like this:
 ----
 
 ifdef::env-github[]
-See the link:../conf/switch/example-switch.cfg[configuration file] describing this switch.
+See the link:../dsatest/conf/switch/example-switch.cfg[configuration file] describing this switch.
 endif::env-github[]
 
 ifndef::env-github[]
@@ -25,7 +25,7 @@ This switch is described as follow:
 
 [source,ini]
 ----
-include::../conf/switch/example-switch.cfg[]
+include::../dsatest/conf/switch/example-switch.cfg[]
 ----
 endif::env-github[]
 
@@ -53,7 +53,7 @@ Describing the internals of the target (which switch port is connected to what f
 Moreover, these files can be shared by people using the same hardware.
 
 ifdef::env-github[]
-See the link:../conf/target/example-target.cfg[configuration file] describing this target.
+See the link:../dsatest/conf/target/example-target.cfg[configuration file] describing this target.
 endif::env-github[]
 
 ifndef::env-github[]
@@ -61,7 +61,7 @@ This target is described as follow:
 
 [source,ini]
 ----
-include::../conf/target/example-target.cfg[]
+include::../dsatest/conf/target/example-target.cfg[]
 ----
 endif::env-github[]
 

--- a/docs/dsatest.1
+++ b/docs/dsatest.1
@@ -2,12 +2,12 @@
 .\"     Title: dsatest
 .\"    Author: [see the "AUTHORS" section]
 .\" Generator: Asciidoctor 1.5.6.1
-.\"      Date: 2017-12-17
+.\"      Date: 2018-03-09
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "DSATEST" "1" "2017-12-17" "\ \&" "\ \&"
+.TH "DSATEST" "1" "2018-03-09" "\ \&" "\ \&"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -39,7 +39,7 @@ Restrict tests to be executed.
 This option can be cumulated.
 .RE
 .sp
-\fB\-\-test\-dir\fP \fITEST_DIR\fP
+\fB\-T\fP \fITEST_DIR\fP, \fB\-\-test\-dir\fP \fITEST_DIR\fP
 .RS 4
 Test directory, defaults to the \fItests\fP directory of the dsatest framework.
 .RE

--- a/docs/dsatest.1
+++ b/docs/dsatest.1
@@ -50,7 +50,7 @@ List tests to be executed.
 If \fB\-t\fP is passed, limit the list to the matching tests.
 .RE
 .sp
-\fB\-B\fP \fIBENCH_FILE\fP, \fB\-\-bench\fP \fIBENCH_FILE\fP
+\fB\-f\fP \fIFILE\fP, \fB\-\-file\fP \fIFILE\fP
 .RS 4
 Bench configuration file, defaults to \fIbench.cfg\fP.
 .RE

--- a/docs/dsatest.1.adoc
+++ b/docs/dsatest.1.adoc
@@ -21,7 +21,7 @@ Show this help message and exit.
 Restrict tests to be executed.
 This option can be cumulated.
 
-*--test-dir* _TEST_DIR_::
+*-T* _TEST_DIR_, *--test-dir* _TEST_DIR_::
 Test directory, defaults to the _tests_ directory of the dsatest framework.
 
 *-l*, *--list*::

--- a/docs/dsatest.1.adoc
+++ b/docs/dsatest.1.adoc
@@ -28,7 +28,7 @@ Test directory, defaults to the _tests_ directory of the dsatest framework.
 List tests to be executed.
 If *-t* is passed, limit the list to the matching tests.
 
-*-B* _BENCH_FILE_, *--bench* _BENCH_FILE_::
+*-f* _FILE_, *--file* _FILE_::
 Bench configuration file, defaults to _bench.cfg_.
 
 *-C* _CONF_DIR_, *--conf-dir* _CONF_DIR_::

--- a/docs/dsatest.1.html
+++ b/docs/dsatest.1.html
@@ -482,7 +482,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p>Restrict tests to be executed.
 This option can be cumulated.</p>
 </dd>
-<dt class="hdlist1"><strong>--test-dir</strong> <em>TEST_DIR</em></dt>
+<dt class="hdlist1"><strong>-T</strong> <em>TEST_DIR</em>, <strong>--test-dir</strong> <em>TEST_DIR</em></dt>
 <dd>
 <p>Test directory, defaults to the <em>tests</em> directory of the dsatest framework.</p>
 </dd>
@@ -561,7 +561,7 @@ Free use of this software is granted under the terms of the <em>TBD</em> License
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-12-17 14:49:29 EST
+Last updated 2018-03-09 15:48:23 EST
 </div>
 </div>
 </body>

--- a/docs/dsatest.1.html
+++ b/docs/dsatest.1.html
@@ -491,7 +491,7 @@ This option can be cumulated.</p>
 <p>List tests to be executed.
 If <strong>-t</strong> is passed, limit the list to the matching tests.</p>
 </dd>
-<dt class="hdlist1"><strong>-B</strong> <em>BENCH_FILE</em>, <strong>--bench</strong> <em>BENCH_FILE</em></dt>
+<dt class="hdlist1"><strong>-f</strong> <em>FILE</em>, <strong>--file</strong> <em>FILE</em></dt>
 <dd>
 <p>Bench configuration file, defaults to <em>bench.cfg</em>.</p>
 </dd>

--- a/docs/example.html
+++ b/docs/example.html
@@ -567,7 +567,7 @@ link0 = eth8</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-10-12 22:27:00 EDT
+Last updated 2018-03-09 16:10:26 EST
 </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -488,8 +488,8 @@ cd dsatest/</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-sh" data-lang="sh">./dsatest -l -B bench.cfg.example
-./dsatest --dry-run -t sanity -B bench.cfg.example</code></pre>
+<pre class="highlight"><code class="language-sh" data-lang="sh">./dsatest -l -f bench.cfg.example
+./dsatest --dry-run -t sanity -f bench.cfg.example</code></pre>
 </div>
 </div>
 </div>
@@ -850,7 +850,7 @@ It was inspired by <strong>dsa-tests</strong>, written by Andrew Lunn.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-12-17 14:48:42 EST
+Last updated 2018-03-09 15:44:38 EST
 </div>
 </div>
 </body>

--- a/dsatest/bench/runner.py
+++ b/dsatest/bench/runner.py
@@ -128,7 +128,7 @@ def main():
                                 this option might be passed several times")
     parser.add_argument('-l', '--list', action='store_true',
                         help="list tests instead of executing them")
-    parser.add_argument('--test-dir', default=test_dir,
+    parser.add_argument('-T', '--test-dir', default=test_dir,
                         help="test folder, default to dsatest's test folder")
     parser.add_argument('-B', '--bench', default="bench.cfg",
                         help="bench configuration file")

--- a/dsatest/bench/runner.py
+++ b/dsatest/bench/runner.py
@@ -130,7 +130,7 @@ def main():
                         help="list tests instead of executing them")
     parser.add_argument('-T', '--test-dir', default=test_dir,
                         help="test folder, default to dsatest's test folder")
-    parser.add_argument('-B', '--bench', default="bench.cfg",
+    parser.add_argument('-f', '--file', default="bench.cfg",
                         help="bench configuration file")
     parser.add_argument('-C', '--conf-dir', default=None,
                         help='path to the configuration directory')
@@ -146,7 +146,7 @@ def main():
         path = os.path.join(os.getcwd(), args.conf_dir)
         settings.set_option(settings.CONF_PATH, os.path.realpath(path))
 
-    bench_cfg = os.path.join(os.getcwd(), args.bench)
+    bench_cfg = os.path.join(os.getcwd(), args.file)
 
     return start_bench(bench_cfg, args.test_dir, args.test, args.list, args.dry_run)
 


### PR DESCRIPTION
A "dsatest" image containing the "dsatest" Python module and executable
(installed by setup.py) can be built with:

    docker build -t dsatest .

and run with:

    docker run --rm --net host --cap-add NET_ADMIN -it -v $PWD/bench.cfg.example:/etc/bench.cfg dsatest --dry-run -t sanity

Note that the bench configuration file is expected to be found in
/etc/bench.cfg thus a valid file must be mounted there.